### PR TITLE
Add LogColorMode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ seclog.Init(seclog.Config{
         LoggerLevel:   loggerLevel,
         LoggerFile:    loggerFile,
         LogFormatText:  false,
+        LogColorMode:  "auto",
 })
 
 logger := seclog.NewLogger(component)
@@ -16,6 +17,7 @@ logger := seclog.NewLogger(component)
 * LoggerLevel: 日志级别由低到高分别为 DEBUG, INFO, WARN, ERROR, FATAL 共5个级别，这里设置的级别是日志输出的最低级别，只有不低于该级别的日志才会输出
 * LoggerFile: 输出日志的文件名，为空则输出到 os.Stdout
 * LogFormatText: 设定日志的输出格式是 json 还是 plaintext
+* LogColorMode: 设定日志的输出是否带颜色，auto: 自动，只有writer是stdout时才带颜色；always：带颜色；never：不带颜色；默认auto
 
 Create logger with multiple sinker
 ```go
@@ -24,6 +26,7 @@ Create logger with multiple sinker
 		LoggerFile:    "test.log",
 		LogFormatText: false,
 		Writers:       []string{"file", "stdout"},
+		LogColorMode:  "auto",
 	})
 
 	logger := seclog.NewLogger("example")

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/go-chassis/seclog
 
 go 1.13
 
-require github.com/go-chassis/openlog v1.1.2
-
-require gopkg.in/natefinch/lumberjack.v2 v2.0.0
+require (
+	github.com/go-chassis/openlog v1.1.2
+	github.com/BurntSushi/toml v0.4.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/go-chassis/openlog v1.1.2 h1:LgGfwwOhpU8c6URV6ADpaRBPVY7Ph1C28jCQ6zzQawQ=
+github.com/go-chassis/openlog v1.1.2/go.mod h1:+eYCADVxWyJkwsFMUBrMxyQlNqW+UUsCxvR2LrYZUaA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/seclog.go
+++ b/seclog.go
@@ -30,6 +30,7 @@ type Config struct {
 	LoggerFile    string   `yaml:"loggerFile"`
 	Writers       []string `yaml:"writers"`
 	LogFormatText bool     `yaml:"logFormatText"`
+	LogColorMode  string   `yaml:"logColorMode"`
 
 	//for rotate
 	RotateDisable bool `yaml:"rotateDisable"`
@@ -58,6 +59,7 @@ func DefaultConfig() *Config {
 		LoggerLevel:   INFO,
 		LoggerFile:    "",
 		LogFormatText: false,
+		LogColorMode:  lager.ColorModeAuto,
 	}
 }
 
@@ -65,6 +67,14 @@ func DefaultConfig() *Config {
 func Init(c Config) {
 	if c.LoggerLevel != "" {
 		config.LoggerLevel = c.LoggerLevel
+	}
+	switch c.LogColorMode {
+	case lager.ColorModeAuto, lager.ColorModeNever, lager.ColorModeAlways:
+		config.LogColorMode = c.LogColorMode
+	case "":
+	default:
+		panic(fmt.Sprintf("log color mode should be: %s/%s/%s, but got: %s",
+			lager.ColorModeAuto, lager.ColorModeAlways, lager.ColorModeNever, c.LogColorMode))
 	}
 
 	if c.LoggerFile != "" {
@@ -139,7 +149,7 @@ func NewLoggerExt(component string, appGUID string) lager.Logger {
 		if !ok {
 			log.Panic("Unknown writer: ", sink)
 		}
-		sink := lager.NewReconfigurableSink(lager.NewWriterSink(sink, writer, lager.DEBUG), lagerLogLevel)
+		sink := lager.NewReconfigurableSink(lager.NewWriterSink(sink, writer, lager.DEBUG, config.LogColorMode), lagerLogLevel)
 		logger.RegisterSink(sink)
 	}
 

--- a/seclog_test.go
+++ b/seclog_test.go
@@ -11,6 +11,7 @@ func TestNewLogger(t *testing.T) {
 		LoggerLevel:   "DEBUG",
 		LogFormatText: true,
 		Writers:       []string{"stdout"},
+		LogColorMode:  "auto",
 	})
 
 	logger := seclog.NewLogger("example")

--- a/third_party/forked/cloudfoundry/lager/writer_sink.go
+++ b/third_party/forked/cloudfoundry/lager/writer_sink.go
@@ -9,6 +9,15 @@ import (
 
 const logBufferSize = 1024
 
+const (
+	// ColorModeAuto only print colorful log when writer is stdout
+	ColorModeAuto = "auto"
+	// ColorModeNever never print colorful log
+	ColorModeNever = "never"
+	// ColorModeAlways always print colorful log
+	ColorModeAlways = "always"
+)
+
 // A Sink represents a write destination for a Logger. It provides
 // a thread-safe interface for writing logs
 type Sink interface {
@@ -21,15 +30,17 @@ type writerSink struct {
 	minLogLevel LogLevel
 	name        string
 	writeL      *sync.Mutex
+	colorMode   string
 }
 
 //NewWriterSink is function which returns new struct object
-func NewWriterSink(name string, writer io.Writer, minLogLevel LogLevel) Sink {
+func NewWriterSink(name string, writer io.Writer, minLogLevel LogLevel, colorMode string) Sink {
 	return &writerSink{
 		writer:      writer,
 		minLogLevel: minLogLevel,
 		writeL:      new(sync.Mutex),
 		name:        name,
+		colorMode:   colorMode,
 	}
 }
 
@@ -37,15 +48,18 @@ func (sink *writerSink) Log(level LogLevel, log []byte) {
 	if level < sink.minLogLevel {
 		return
 	}
-	if sink.name == "stdout" {
-		if bytes.Contains(log, []byte("WARN")) {
-			log = bytes.Replace(log, []byte("WARN"), color.WarnByte, -1)
-		} else if bytes.Contains(log, []byte("ERROR")) {
-			log = bytes.Replace(log, []byte("ERROR"), color.ErrorByte, -1)
-		} else if bytes.Contains(log, []byte("FATAL")) {
+	if sink.colorMode == ColorModeAlways ||
+		(sink.colorMode == ColorModeAuto && sink.name == "stdout") {
+		switch level {
+		case FATAL:
 			log = bytes.Replace(log, []byte("FATAL"), color.FatalByte, -1)
-		} else if bytes.Contains(log, []byte("INFO")) {
+		case ERROR:
+			log = bytes.Replace(log, []byte("ERROR"), color.ErrorByte, -1)
+		case WARN:
+			log = bytes.Replace(log, []byte("WARN"), color.WarnByte, -1)
+		case INFO:
 			log = bytes.Replace(log, []byte("INFO"), color.InfoByte, -1)
+		default:
 		}
 	}
 	log = append(log, '\n')


### PR DESCRIPTION
若用户将打印到标准输出的日志重定向到文件，则日志中将带有颜色控制字符。为适配这种使用场景，添加颜色控制选项，允许强制开启、关闭，或自动控制。